### PR TITLE
Fix issue where interpolation routine was accessing out of bounds value

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -957,7 +957,8 @@ contains
 
         do while (n .LE. n_S)
             nRow = rowValues(n)
-            do while ( rowValues(n) .EQ. nRow )
+            ! Do while n<size(rowVals), where size(rowVals) = n_S
+            do while ( (n.LE.n_S) .AND. (rowValues(n).EQ.nRow) )
                 nCol = colValues(n)
                 rhs = rhs + dataIn(nCol) * sValues(n)
                 n = n + 1


### PR DESCRIPTION
Previously, the inner loop would iterate until it accessed an out of bounds value. This did not seem to cause any issues in practice because the out of bounds value appeared in the logic check `rowValues(n).EQ.nRows`, where `nRows` is always a nonzero positive value, and the out of bounds value returned by `rowValues(n)` was equal to 0. Therefore, the inner loop would exit the loop at the right time, but for the wrong reason.

To fix this issue, I added a check in the inner loop that ensures `n` does not exceed the size of `rowValues`, where `size(rowValues)` equals `n_S`. This looks repetitive since the outer loop also uses the same logic (`n.LE.n_S`), but as far as I can tell both loops are necessary to properly track the row sums, so it can't be simplified any further.

I confirmed that the previous version of the code would exit the loop after the same number of iterations as this commit and checked that the average kinetic energy values were not changed from one run to the next (I ran the code for a full day and then checked the last few KE values, shown below).

Previous code:
```
ncdump -v kineticEnergyCellAvg globalStats.2012-01-01_00.00.00.nc |tail
    4.79336250323068e-07, 5.11332495627898e-07, 5.42745580660935e-07,
    5.7388481089121e-07, 6.05765811150021e-07, 6.39790201333673e-07,
    6.77702743028263e-07, 7.21130820886044e-07, 7.70916882810505e-07,
    8.26973802990961e-07, 8.87740528871718e-07, 9.5047456880545e-07,
    1.01171722678606e-06, 1.06847730081553e-06, 1.11821830065758e-06,
    1.16065525391938e-06, 1.19679335941936e-06, 1.22947711099054e-06,
    1.26284007921751e-06, 1.30117929882643e-06, 1.34806051171648e-06,
    1.40535200069016e-06, 1.47278480483318e-06, 1.54755744305108e-06,
    1.62515857125841e-06 ;
```

This commit:
```
ncdump -v kineticEnergyCellAvg globalStats.2012-01-01_00.00.00.nc |tail
    4.79336250323068e-07, 5.11332495627898e-07, 5.42745580660935e-07,
    5.7388481089121e-07, 6.05765811150021e-07, 6.39790201333673e-07,
    6.77702743028263e-07, 7.21130820886044e-07, 7.70916882810505e-07,
    8.26973802990961e-07, 8.87740528871718e-07, 9.5047456880545e-07,
    1.01171722678606e-06, 1.06847730081553e-06, 1.11821830065758e-06,
    1.16065525391938e-06, 1.19679335941936e-06, 1.22947711099054e-06,
    1.26284007921751e-06, 1.30117929882643e-06, 1.34806051171648e-06,
    1.40535200069016e-06, 1.47278480483318e-06, 1.54755744305108e-06,
    1.62515857125841e-06 ;
```