### PR TITLE
Fix interpolation issue (again!)

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -956,13 +956,22 @@ contains
         rhs = 0.0_RKIND
 
         do while (n .LE. n_S)
+
             nRow = rowValues(n)
-            ! Do while n<size(rowVals), where size(rowVals) = n_S
-            do while ( (n.LE.n_S) .AND. (rowValues(n).EQ.nRow) )
+
+            ! Iterate up until the second to last element
+            do while ( (n.LT.(n_S)) .AND. (rowValues(n).EQ.nRow) )
                 nCol = colValues(n)
                 rhs = rhs + dataIn(nCol) * sValues(n)
                 n = n + 1
             end do
+            ! If we're at the last element, do one last calucation, no loop
+            if ( (n.EQ.n_S) .AND. (rowValues(n).EQ.nRow) ) then
+                nCol = colValues(n)
+                rhs = rhs + dataIn(nCol) * sValues(n)
+                n = n + 1
+            endif
+            
             dataOut(nRow) = rhs
             rhs = 0.0_RKIND
         end do


### PR DESCRIPTION
This is a new fix that puts the final inner loop iteration into an if statement to prevent any possible out of bounds access. I have confirmed that the kinetic energy values are the same before and after the changes. I think we should wait until @hollyhan confirms that this does not cause an error before merging.

KE tests

Current commit:
```
ncdump -v kineticEnergyCellAvg globalStats.2012-01-01_00.00.00.nc |tail
    4.79336250323068e-07, 5.11332495627898e-07, 5.42745580660935e-07,
    5.7388481089121e-07, 6.05765811150021e-07, 6.39790201333673e-07,
    6.77702743028263e-07, 7.21130820886044e-07, 7.70916882810505e-07,
    8.26973802990961e-07, 8.87740528871718e-07, 9.5047456880545e-07,
    1.01171722678606e-06, 1.06847730081553e-06, 1.11821830065758e-06,
    1.16065525391938e-06, 1.19679335941936e-06, 1.22947711099054e-06,
    1.26284007921751e-06, 1.30117929882643e-06, 1.34806051171648e-06,
    1.40535200069016e-06, 1.47278480483318e-06, 1.54755744305108e-06,
    1.62515857125841e-06 ;
```

Before changes:
```
ncdump -v kineticEnergyCellAvg globalStats.2012-01-01_00.00.00.nc |tail
    4.79336250323068e-07, 5.11332495627898e-07, 5.42745580660935e-07,
    5.7388481089121e-07, 6.05765811150021e-07, 6.39790201333673e-07,
    6.77702743028263e-07, 7.21130820886044e-07, 7.70916882810505e-07,
    8.26973802990961e-07, 8.87740528871718e-07, 9.5047456880545e-07,
    1.01171722678606e-06, 1.06847730081553e-06, 1.11821830065758e-06,
    1.16065525391938e-06, 1.19679335941936e-06, 1.22947711099054e-06,
    1.26284007921751e-06, 1.30117929882643e-06, 1.34806051171648e-06,
    1.40535200069016e-06, 1.47278480483318e-06, 1.54755744305108e-06,
    1.62515857125841e-06 ;
```